### PR TITLE
fix a bug that place portal at someplace may crash the game.

### DIFF
--- a/sp/src/game/client/portal/ModSettingsPanel.cpp
+++ b/sp/src/game/client/portal/ModSettingsPanel.cpp
@@ -98,14 +98,10 @@ CModSettingsPanel::CModSettingsPanel(vgui::VPANEL parent) : BaseClass(NULL, "Mod
 	m_pChellModel = dynamic_cast<CheckButton*>( FindChildByName("ChellModel", true) );
 	m_pChellModel->SizeToContents();
 	m_pBadGordonModel = dynamic_cast<CheckButton*>(FindChildByName("BadGordonModel", true));
-	if (m_pBadGordonModel) {
-		m_pBadGordonModel->SizeToContents();
-	}
+	m_pBadGordonModel->SizeToContents();
 	m_pLoweringAnim = dynamic_cast<CvarToggleCheckButton<ConVarRef>*>(FindChildByName("LoweringAnim", true));
-	if (m_pLoweringAnim) {
-		m_pLoweringAnim->SetCvarName("allow_portalgun_lowering_anim");
-		m_pLoweringAnim->SizeToContents();
-	}
+	m_pLoweringAnim->SetCvarName("allow_portalgun_lowering_anim");
+	m_pLoweringAnim->SizeToContents();
 	cl_playermodel = cvar->FindVar("cl_playermodel");
 
 	DevMsg("ModSettingsPanel has been constructed\n");

--- a/sp/src/game/client/portal/ModSettingsPanel.cpp
+++ b/sp/src/game/client/portal/ModSettingsPanel.cpp
@@ -98,10 +98,14 @@ CModSettingsPanel::CModSettingsPanel(vgui::VPANEL parent) : BaseClass(NULL, "Mod
 	m_pChellModel = dynamic_cast<CheckButton*>( FindChildByName("ChellModel", true) );
 	m_pChellModel->SizeToContents();
 	m_pBadGordonModel = dynamic_cast<CheckButton*>(FindChildByName("BadGordonModel", true));
-	m_pBadGordonModel->SizeToContents();
+	if (m_pBadGordonModel) {
+		m_pBadGordonModel->SizeToContents();
+	}
 	m_pLoweringAnim = dynamic_cast<CvarToggleCheckButton<ConVarRef>*>(FindChildByName("LoweringAnim", true));
-	m_pLoweringAnim->SetCvarName("allow_portalgun_lowering_anim");
-	m_pLoweringAnim->SizeToContents();
+	if (m_pLoweringAnim) {
+		m_pLoweringAnim->SetCvarName("allow_portalgun_lowering_anim");
+		m_pLoweringAnim->SizeToContents();
+	}
 	cl_playermodel = cvar->FindVar("cl_playermodel");
 
 	DevMsg("ModSettingsPanel has been constructed\n");

--- a/sp/src/game/client/portal/c_portal_player.cpp
+++ b/sp/src/game/client/portal/c_portal_player.cpp
@@ -21,9 +21,8 @@
 #undef CPortal_Player	
 #endif
 
-
-#define REORIENTATION_RATE 120.0f
-#define REORIENTATION_ACCELERATION_RATE 400.0f
+ConVar cl_reorient_rate( "cl_reorient_rate", "1000", FCVAR_ARCHIVE, "Rate at which the player reorients to the camera" );
+ConVar cl_reorient_acceleration_rate( "cl_reorient_acceleration_rate", "5000", FCVAR_ARCHIVE, "Acceleration rate at which the player reorients to the camera" );
 
 ConVar cl_reorient_in_air("cl_reorient_in_air", "1", FCVAR_ARCHIVE, "Allows the player to only reorient from being upside down while in the air." ); 
 
@@ -159,7 +158,7 @@ void C_Portal_Player::FixTeleportationRoll( void )
 
 	if ( bForcePitchReorient )
 	{
-		m_fReorientationRate = REORIENTATION_RATE * ( ( bOnGround ) ? ( 2.0f ) : ( 1.0f ) );
+		m_fReorientationRate = cl_reorient_rate.GetFloat() * ( ( bOnGround ) ? ( 2.0f ) : ( 1.0f ) );
 	}
 	else
 	{
@@ -173,26 +172,26 @@ void C_Portal_Player::FixTeleportationRoll( void )
 
 	if ( vCurrentUp.z < 0.75f )
 	{
-		m_fReorientationRate += gpGlobals->frametime * REORIENTATION_ACCELERATION_RATE;
+		m_fReorientationRate += gpGlobals->frametime * cl_reorient_acceleration_rate.GetFloat();
 
 		// Upright faster if on the ground
-		float fMaxReorientationRate = REORIENTATION_RATE * ( ( bOnGround ) ? ( 2.0f ) : ( 1.0f ) );
+		float fMaxReorientationRate = cl_reorient_rate.GetFloat() * ( ( bOnGround ) ? ( 2.0f ) : ( 1.0f ) );
 		if ( m_fReorientationRate > fMaxReorientationRate )
 			m_fReorientationRate = fMaxReorientationRate;
 	}
 	else
 	{
-		if ( m_fReorientationRate > REORIENTATION_RATE * 0.5f )
+		if ( m_fReorientationRate > cl_reorient_rate.GetFloat() * 0.5f )
 		{
-			m_fReorientationRate -= gpGlobals->frametime * REORIENTATION_ACCELERATION_RATE;
-			if ( m_fReorientationRate < REORIENTATION_RATE * 0.5f )
-				m_fReorientationRate = REORIENTATION_RATE * 0.5f;
+			m_fReorientationRate -= gpGlobals->frametime * cl_reorient_acceleration_rate.GetFloat();
+			if ( m_fReorientationRate < cl_reorient_rate.GetFloat() * 0.5f )
+				m_fReorientationRate = cl_reorient_rate.GetFloat() * 0.5f;
 		}
-		else if ( m_fReorientationRate < REORIENTATION_RATE * 0.5f )
+		else if ( m_fReorientationRate < cl_reorient_rate.GetFloat() * 0.5f )
 		{
-			m_fReorientationRate += gpGlobals->frametime * REORIENTATION_ACCELERATION_RATE;
-			if ( m_fReorientationRate > REORIENTATION_RATE * 0.5f )
-				m_fReorientationRate = REORIENTATION_RATE * 0.5f;
+			m_fReorientationRate += gpGlobals->frametime * cl_reorient_acceleration_rate.GetFloat();
+			if ( m_fReorientationRate > cl_reorient_rate.GetFloat() * 0.5f )
+				m_fReorientationRate = cl_reorient_rate.GetFloat() * 0.5f;
 		}
 	}
 

--- a/sp/src/game/client/portal/c_prop_portal.cpp
+++ b/sp/src/game/client/portal/c_prop_portal.cpp
@@ -576,7 +576,7 @@ void C_Prop_Portal::OnDataChanged( DataUpdateType_t updateType )
 			Vector vScaledRight = m_vRight * (PORTAL_HALF_WIDTH * 0.95f);
 			Vector vScaledUp = m_vUp * (PORTAL_HALF_HEIGHT  * 0.95f);
 
-			m_PortalSimulator.MoveTo( GetNetworkOrigin(), GetNetworkAngles() );
+			m_PortalSimulator.MoveTo(GetNetworkOrigin(), GetNetworkAngles());
 
 			//update our associated portal environment
 			//CPortal_PhysicsEnvironmentMgr::CreateEnvironment( this );
@@ -794,6 +794,7 @@ void C_Prop_Portal::OnDataChanged( DataUpdateType_t updateType )
 	}
 	else
 	{
+	Deactive:
 		g_pPortalRender->RemovePortal( this );
 
 		m_PortalSimulator.DetachFromLinked();

--- a/sp/src/game/server/portal/prop_portal.h
+++ b/sp/src/game/server/portal/prop_portal.h
@@ -90,7 +90,7 @@ public:
 	void					ForceEntityToFitInPortalWall( CBaseEntity *pEntity ); //projects an object's center into the middle of the portal wall hall, and traces back to where it wants to be
 
 	void					PlacePortal( const Vector &vOrigin, const QAngle &qAngles, float fPlacementSuccess, bool bDelay = false );
-	void					NewLocation( const Vector &vOrigin, const QAngle &qAngles );
+	void					NewLocation(const Vector &vOrigin, const QAngle &qAngles, const bool isFailReplace = false);
 
 	void					ResetModel( void ); //sets the model and bounding box
 	void					DoFizzleEffect( int iEffect, bool bDelayedPos = true ); //display cool visual effect
@@ -107,7 +107,7 @@ public:
 	void					InputFizzle( inputdata_t &inputdata );
 	void					InputNewLocation( inputdata_t &inputdata );
 
-	void					UpdatePortalLinkage( void );
+	bool					UpdatePortalLinkage(void);
 	void					UpdatePortalTeleportMatrix( void ); //computes the transformation from this portal to the linked portal, and will update the remote matrix as well
 
 	//void					SendInteractionMessage( CBaseEntity *pEntity, bool bEntering ); //informs clients that the entity is interacting with a portal (mostly used for clip planes)

--- a/sp/src/game/shared/portal/PortalSimulation.h
+++ b/sp/src/game/shared/portal/PortalSimulation.h
@@ -280,7 +280,7 @@ public:
 	CPortalSimulator( void );
 	~CPortalSimulator( void );
 
-	void				MoveTo( const Vector &ptCenter, const QAngle &angles );
+	bool				MoveTo(const Vector &ptCenter, const QAngle &angles);
 	void				ClearEverything( void );
 
 	void				AttachTo( CPortalSimulator *pLinkedPortalSimulator );
@@ -374,8 +374,8 @@ protected:
 	void				ClearLinkedEntities( void ); //gets rid of transformed shadow clones
 #endif
 
-	void				CreateAllCollision( void );
-	void				CreateLocalCollision( void );
+	bool				CreateAllCollision(void);
+	bool				CreateLocalCollision(void);
 	void				CreateLinkedCollision( void );
 
 	void				ClearAllCollision( void );


### PR DESCRIPTION
Place the portal on someplace will crash the game. It is because that CPortalSimulator::CreateLocalCollision fails on ConvertPolyhedronsToCollideable and returns NULL. I've made a check and if it fails, the portal will not be placed on the new place.