### PR TITLE
Fix camera detach counter

### DIFF
--- a/sp/src/game/server/portal/npc_security_camera.cpp
+++ b/sp/src/game/server/portal/npc_security_camera.cpp
@@ -1126,7 +1126,8 @@ void PlayDismountSounds()
 	{
 		gameeventmanager->FireEvent( event );
 	}
-	
+	pPlayer->IncNumCamerasDetatched();
+
 	// If glados is currently talking, don't let her talk over herself or interrupt a potentially important speech.
 	// Should we play the dismount sound after she's done? or is that too disjointed from the camera dismounting act to make sense...
 	if ( IsRunningScriptedScene( pGlaDOS, false ) )
@@ -1134,7 +1135,6 @@ void PlayDismountSounds()
 		return;
 	}
 
-	pPlayer->IncNumCamerasDetatched();
 	int iNumCamerasDetatched = pPlayer->GetNumCamerasDetatched();
 
 	// If they've knocked down every one possible, play special '1' sound.


### PR DESCRIPTION
Fixes the bug with the camera detach counter where the counter wouldn't increment correctly if GLaDOS was still talking, resulting in an incorrect dialogue playing when the counter reaches 33.

The bug was explained in [this youtube video](https://youtu.be/niYKpbICJus), so I've decided to fix it in your Source 2013 port. Although, I'm not sure whether you accept these kinds of fixes or not, considering that it's a fix for the base game and not the actual port 😅 